### PR TITLE
Suppress RNG warnings in new R version

### DIFF
--- a/tests/testthat/test_MFPCA_calculation.R
+++ b/tests/testthat/test_MFPCA_calculation.R
@@ -141,6 +141,8 @@ test_that("test MFPCA main function", {
   expect_equal(mixed$normFactors[1], 0.97475, tolerance = 1e-5)
   
   ### Test bootstrap
+  # suppress warnings in transition to new RNG, as proposed by CRAN maintainers
+  suppressWarnings(RNGversion("3.5.0")) 
   set.seed(2)
   splinesBoot <- MFPCA(sim$simData, M = 5, uniExpansions = list(list(type = "splines1D", k = 10),
                                                             list(type = "splines1D", k = 10)),

--- a/tests/testthat/test_fftw.R
+++ b/tests/testthat/test_fftw.R
@@ -102,6 +102,8 @@ test_that("test univariate DCT 3D", {
 ##### Inverse DCT #####
 
 test_that("Test fftw: IDCT", {
+  # suppress warnings in transition to new RNG, as proposed by CRAN maintainers
+  suppressWarnings(RNGversion("3.5.0")) 
   set.seed(4)
   scores <- rnorm(25, sd = 25:1/25)
   

--- a/tests/testthat/test_univDecomp.R
+++ b/tests/testthat/test_univDecomp.R
@@ -173,6 +173,8 @@ test_that("PACE function", {
   expect_equal(pcaPD$sigma2, 0.01102, tolerance = 1e-5)
   
   # test also for irregular data
+  # suppress warnings in transition to new RNG, as proposed by CRAN maintainers
+  suppressWarnings(RNGversion("3.5.0")) 
   set.seed(2)
   f1sparse <- sparsify(f1, minObs=  20, maxObs = 50)
   i1 <- irregFunData(argvals = apply(f1sparse@X,1, function(x){f1sparse@argvals[[1]][which(!is.na(x))]}), X = apply(f1sparse@X, 1, na.omit))


### PR DESCRIPTION
Following instructions from CRAN maintainers:

The check problems with current R-devel are from

     • The default method for generating from a discrete uniform
       distribution (used in sample(), for instance) has been changed.
       ...
       The previous method can be requested using RNGkind() or
       RNGversion() if necessary for reproduction of old results.

To make your package successfully pass the checks for current R-devel
and R-release you may find it most convenient to insert

  suppressWarnings(RNGversion("3.5.0"))

before calling set.seed() in your example, vignette and test code (where
the difference in RNG sample kinds matters, of course).

Note that this ensures using the (old) non-uniform "Rounding" sampler
for all 3.x versions of R, and does not add an R version dependency.
Note also that the new "Rejection" sampler which R will use from 3.6.0
onwards by default is definitely preferable over the old one, so that
the above should really only be used as a temporary measure for
reproduction of the previous behavior (and the run time tests relying on
it).