### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The `MFPCA` package depends on the `R`-package [`funData`](https://CRAN.R-projec
 
 The theoretical foundations of multivariate functional principal component analysis are described in:
 
-C. Happ, S. Greven (2018): [Multivariate Functional Principal Component Analysis for Data Observed on Different (Dimensional) Domains.](https://dx.doi.org/10.1080/01621459.2016.1273115)
+C. Happ, S. Greven (2018): [Multivariate Functional Principal Component Analysis for Data Observed on Different (Dimensional) Domains.](https://doi.org/10.1080/01621459.2016.1273115)
     *Journal of the American Statistical Association*, 113(522): 649-659 .
 
 ## Bug reports ##

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -23,5 +23,5 @@ citEntry(
   issue = "522",
   pages = "649-659",
   doi =  "10.1080/01621459.2016.1273115",
-  textVersion = "C. Happ and S. Greven (2018). Multivariate Functional Principal Component Analysis for Data Observed on Different (Dimensional) Domains. Journal of the American Statistical Association, 113(522): 649-659. http://dx.doi.org/10.1080/01621459.2016.1273115."
+  textVersion = "C. Happ and S. Greven (2018). Multivariate Functional Principal Component Analysis for Data Observed on Different (Dimensional) Domains. Journal of the American Statistical Association, 113(522): 649-659. https://doi.org/10.1080/01621459.2016.1273115."
 )


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!